### PR TITLE
Update Quill & add support for a "list-only" mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ DerbyQuill.prototype._updateDelta = function() {
   var pass = {source: this.quill.id};
   // TODO: Change to setDiffDeep once we figure out the error
   // shown here: https://lever.slack.com/files/jon/F0GH44U74/screen_shot_2015-12-13_at_3.00.37_pm.png
-  this.delta.pass(pass).set(this.quill.editor.doc.toDelta());
+  this.delta.pass(pass).setDiffDeep(deepyCopy(this.quill.editor.doc.toDelta()));
 }
 
 DerbyQuill.prototype.clearFormatting = function() {
@@ -147,4 +147,8 @@ DerbyQuill.prototype.isFocused = function() {
 
 DerbyQuill.prototype.setHTML = function(html) {
   return this.quill.setHTML(html);
+}
+
+deepyCopy = function(obj) {
+  return JSON.parse(JSON.stringify(obj));
 }

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ DerbyQuill.prototype.create = function() {
   });
 
   quill.on('selection-change', function(range) {
-    self.model.set('isFocused', !!range);
+    self.model.set('editorFocused', !!range);
     self.updateActiveFormats(range);
   });
 
@@ -151,8 +151,8 @@ DerbyQuill.prototype.toggleFormat = function(type) {
   this.setFormat(type, value);
 };
 
-DerbyQuill.prototype.setFormat = function(type, value, isFocused) {
-  if (!isFocused) this.quill.focus();
+DerbyQuill.prototype.setFormat = function(type, value, editorFocused) {
+  if (!editorFocused) this.quill.focus();
   var self = this;
 
   // HACK: Selecting an option from a dropdown
@@ -161,7 +161,7 @@ DerbyQuill.prototype.setFormat = function(type, value, isFocused) {
   // returned to the editor before actually applying
   // the format.
   window.requestAnimationFrame(function() {
-    if (!isFocused) self.quill.focus();
+    if (!editorFocused) self.quill.focus();
     var range;
 
     // if we are in list mode and applying a list style, then
@@ -200,7 +200,7 @@ DerbyQuill.prototype.focus = function() {
     this.quill.setSelection(end, end);
     var range = this.quill.getSelection();
     this.updateActiveFormats(range);
-    this.model.set('isFocused', true);
+    this.model.set('editorFocused', true);
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -125,26 +125,23 @@ DerbyQuill.prototype.setFormat = function(type, value) {
   // causes some interesting focus events which
   // require us to wait until focus has properly
   // returned to the editor before actually applying
-  // the format
+  // the format.
   window.requestAnimationFrame(function() {
     self.quill.focus();
-    if (self.model.get('mode') === 'list') {
-      console.log('toggling format in list mode');
-      var previousRange = self.quill.getSelection(true);
-      var end = self.quill.getLength() || 0
-      self.quill.setSelection(0, end);
-      var range = self.quill.getSelection(true);
-      console.log('applying format', range, type, value);
-      self.toolbar._applyFormat(type, range, value);
-      self.activeFormats.set(type, value);
-      console.log('returning selection to', previousRange);
-      self.quill.setSelection(previousRange.start, previousRange.end);
+    var range;
+    // if we are in list mode and applying a list style, then
+    // we force the editor to apply that style to the entire
+    // contents of the editor
+    if (self.model.get('mode') === 'list' && (type === 'list' || type === 'bullet')) {
+      // console.log('toggling format in list mode');
+      var end = self.quill.getLength() || 0;
+      range = new Range(0, end);
     } else {
-      var range = self.quill.getSelection(true);
-      console.log('applying format', range, type, value);
-      self.toolbar._applyFormat(type, range, value);
-      self.activeFormats.set(type, value);
+      range = self.quill.getSelection(true);
     }
+    // console.log('applying format', range, type, value);
+    self.toolbar._applyFormat(type, range, value);
+    self.activeFormats.set(type, value);
   });
 };
 

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ DerbyQuill.prototype.init = function() {
   this.quill = null;
   this.activeFormats = this.model.at('activeFormats');
   this.delta = this.model.at('delta');
+  this.htmlValue = this.model.at('htmlValue');
   this.htmlResult = this.model.at('htmlResult');
   this.plainText = this.model.at('plainText');
   this.model.start('shouldShowPlaceholder', 'htmlResult', function(html) {
@@ -82,7 +83,12 @@ DerbyQuill.prototype.create = function() {
   }
 
   var delta = this.delta.getDeepCopy();
-  if (delta) quill.setContents(delta);
+  var htmlValue = this.htmlValue.get();
+  if (delta) {
+    quill.setContents(delta);
+  } else if (htmlValue) {
+    this.setHTML(htmlValue);
+  }
 };
 
 DerbyQuill.prototype._updateDelta = function() {

--- a/index.js
+++ b/index.js
@@ -103,12 +103,22 @@ DerbyQuill.prototype._updateDelta = function() {
 DerbyQuill.prototype.clearFormatting = function() {
   this.quill.focus();
   var range = this.quill.getSelection(true);
-  var formats = this.quill.editor.doc.formats;
-  for (type in formats) {
+  var lineFormats = this.toolbar._getLineActive(range);
+  var formats = {};
+  if (range.isCollapsed()) {
+    formats = this.getActiveFormats(range);
+  } else {
+    formats = this.quill.editor.doc.formats;
+  }
+  for (var lineType in lineFormats) {
+    this.toolbar._applyFormat(type, range, false);
+  }
+  for (var type in formats) {
     // We don't use setFormat here because we want to avoid
     // focusing the editor for each format
     this.toolbar._applyFormat(type, range, false);
   }
+  this.updateActiveFormats();
 };
 
 DerbyQuill.prototype.toggleFormat = function(type) {

--- a/index.js
+++ b/index.js
@@ -33,7 +33,8 @@ DerbyQuill.prototype.init = function() {
 DerbyQuill.prototype.create = function() {
   var self = this;
   // TODO: remove this
-  window.Quill = Quill
+  window.Quill = Quill;
+  window.dom = dom;
   // Setup quill and initalize referneces
   var quill = this.quill = new Quill(this.editor);
   quill.addModule('toolbar', {
@@ -105,8 +106,14 @@ DerbyQuill.prototype.toggleFormat = function(type) {
 
 DerbyQuill.prototype.setFormat = function(type, value) {
   this.quill.focus();
-  var range = this.quill.getSelection(true);
-  this.toolbar._applyFormat(type, range, value);
+  var self = this;
+  window.requestAnimationFrame(function() {
+    self.quill.focus();
+    var range = self.quill.getSelection(true);
+    console.log('applying format', type, range, value);
+    self.toolbar._applyFormat(type, range, value);
+    self.activeFormats.set(type, value);
+  });
 };
 
 DerbyQuill.prototype.updateActiveFormats = function(range) {

--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ var MIXED_FORMAT_VALUE = '*';
 
 module.exports = DerbyQuill;
 function DerbyQuill() {}
+
+DerbyQuill.Range = Range
+
 DerbyQuill.prototype.view = __dirname;
 
 DerbyQuill.prototype.init = function() {

--- a/index.js
+++ b/index.js
@@ -135,6 +135,7 @@ DerbyQuill.prototype.setFormat = function(type, value, isFocused) {
     if (self.model.get('mode') === 'list' && (type === 'list' || type === 'bullet')) {
       var end = self.quill.getLength() || 0;
       range = new Range(0, end);
+      value = true
     } else {
       range = self.quill.getSelection(true);
     }

--- a/index.js
+++ b/index.js
@@ -92,17 +92,19 @@ DerbyQuill.prototype.clearFormatting = function() {
   var range = this.quill.getSelection(true);
   var formats = this.quill.editor.doc.formats
   for (type in formats) {
-    this.setFormat(type, false);
+    // We don't use setFormat here because we want to avoid
+    // focusing the editor for each format
+    this.toolbar._applyFormat(type, range, false);
   }
 };
 
 DerbyQuill.prototype.toggleFormat = function(type) {
   var value = !this.activeFormats.get(type);
-  this.quill.focus()
   this.setFormat(type, value);
 };
 
 DerbyQuill.prototype.setFormat = function(type, value) {
+  this.quill.focus();
   var range = this.quill.getSelection(true);
   this.toolbar._applyFormat(type, range, value);
 };

--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ DerbyQuill.prototype._updateDelta = function() {
   var pass = {source: this.quill.id};
   // TODO: Change to setDiffDeep once we figure out the error
   // shown here: https://lever.slack.com/files/jon/F0GH44U74/screen_shot_2015-12-13_at_3.00.37_pm.png
-  this.delta.pass(pass).setDiffDeep(deepyCopy(this.quill.editor.doc.toDelta()));
+  this.delta.pass(pass).set(deepyCopy(this.quill.editor.doc.toDelta()));
 }
 
 DerbyQuill.prototype.clearFormatting = function() {

--- a/index.js
+++ b/index.js
@@ -118,8 +118,8 @@ DerbyQuill.prototype.toggleFormat = function(type) {
   this.setFormat(type, value);
 };
 
-DerbyQuill.prototype.setFormat = function(type, value) {
-  this.quill.focus();
+DerbyQuill.prototype.setFormat = function(type, value, isFocused) {
+  if (!isFocused) this.quill.focus();
   var self = this;
   // HACK: Selecting an option from a dropdown
   // causes some interesting focus events which
@@ -127,7 +127,7 @@ DerbyQuill.prototype.setFormat = function(type, value) {
   // returned to the editor before actually applying
   // the format.
   window.requestAnimationFrame(function() {
-    self.quill.focus();
+    if (!isFocused) self.quill.focus();
     var range;
     // if we are in list mode and applying a list style, then
     // we force the editor to apply that style to the entire
@@ -139,7 +139,7 @@ DerbyQuill.prototype.setFormat = function(type, value) {
     } else {
       range = self.quill.getSelection(true);
     }
-    // console.log('applying format', range, type, value);
+    console.log('applying format', range, type, value);
     self.toolbar._applyFormat(type, range, value);
     self.activeFormats.set(type, value);
   });

--- a/index.js
+++ b/index.js
@@ -41,8 +41,9 @@ DerbyQuill.prototype.create = function() {
   quill.addModule('toolbar', {
     container: window.document.createElement('div')
   });
+  this.toolbar = quill.modules['toolbar']
+  this.keyboard = quill.modules['keyboard']
   if (this.model.get('focus')) this.focus();
-
   // Bind Event listners
   this.model.on('all', 'delta.**', function(path, evtName, value, prev, passed) {
     // This change originated from this component so we

--- a/index.js
+++ b/index.js
@@ -28,8 +28,14 @@ DerbyQuill.prototype.create = function() {
   window.Quill = Quill
   var quill = this.quill = new Quill(this.editor);
   var self = this;
+
+  this.model.on('change', 'delta.**', function(path, value, previous, passed) {
+    var delta = self.delta.getDeepCopy()
+    if (delta) self.quill.setContents(delta)
+  });
+
   quill.on('text-change', function() {
-    self.delta.setDiffDeep(quill.editor.doc.toDelta())
+    self.delta.pass({source: quill}).setDiffDeep(quill.editor.doc.toDelta())
     self.htmlValue.set(quill.getHTML());
     var range = quill.getSelection(true);
     self.updateActiveFormats(range);

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Quill = require('quill');
+var Quill = require('lever-quill');
 var Range = Quill.require('range');
 var dom = Quill.require('dom');
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ DerbyQuill.prototype.init = function() {
   this.initialHtml = this.model.at('initialHtml');
   this.htmlResult = this.model.at('htmlResult');
   this.plainText = this.model.at('plainText');
+  this.emptyRange = new Range(0,0);
   this.model.start('shouldShowPlaceholder', 'htmlResult', function(html) {
     if (html === '<div><br></div>') return true;
     return !html;
@@ -100,7 +101,10 @@ DerbyQuill.prototype.create = function() {
   // once the latest develop branch of Quill has been published
   quill.getSelection = function(ignoreFocus) {
     this.editor.checkUpdate();
-    return this.editor.selection.getRange(ignoreFocus);
+    // we return the empty range as a fallback because quill does not deal with
+    // being passed null as a selection well, and getSelection can return null
+    // in some cases, resulting in an error
+    return this.editor.selection.getRange(ignoreFocus) || this.emptyRange;
   };
 
   var delta = this.delta.getDeepCopy();

--- a/index.js
+++ b/index.js
@@ -87,11 +87,11 @@ DerbyQuill.prototype.clearFormatting = function() {
 
 DerbyQuill.prototype.toggleFormat = function(type) {
   var value = !this.activeFormats.get(type);
+  this.quill.focus()
   this.setFormat(type, value);
 };
 
 DerbyQuill.prototype.setFormat = function(type, value) {
-  this.quill.focus();
   var range = this.quill.getSelection(true);
   this.toolbar._applyFormat(type, range, value);
 };

--- a/index.js
+++ b/index.js
@@ -133,13 +133,11 @@ DerbyQuill.prototype.setFormat = function(type, value, isFocused) {
     // we force the editor to apply that style to the entire
     // contents of the editor
     if (self.model.get('mode') === 'list' && (type === 'list' || type === 'bullet')) {
-      // console.log('toggling format in list mode');
       var end = self.quill.getLength() || 0;
       range = new Range(0, end);
     } else {
       range = self.quill.getSelection(true);
     }
-    console.log('applying format', range, type, value);
     self.toolbar._applyFormat(type, range, value);
     self.activeFormats.set(type, value);
   });

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ DerbyQuill.prototype.init = function() {
   this.quill = null;
   this.activeFormats = this.model.at('activeFormats');
   this.delta = this.model.at('delta');
-  this.htmlValue = this.model.at('htmlValue');
+  this.markup = this.model.at('markup');
+  this.plainText = this.model.at('plainText');
 };
 
 DerbyQuill.prototype.create = function() {
@@ -29,14 +30,15 @@ DerbyQuill.prototype.create = function() {
   var quill = this.quill = new Quill(this.editor);
   var self = this;
 
-  this.model.on('change', 'delta.**', function(path, value, previous, passed) {
-    var delta = self.delta.getDeepCopy()
-    if (delta) self.quill.setContents(delta)
+  this.model.on('change', 'delta.**', function() {
+    var delta = self.delta.getDeepCopy();
+    if (delta) self.quill.setContents(delta);
   });
 
   quill.on('text-change', function() {
     self.delta.pass({source: quill}).setDiffDeep(quill.editor.doc.toDelta())
-    self.htmlValue.set(quill.getHTML());
+    self.markup.set(quill.getHTML());
+    self.plainText.set(quill.getText());
     var range = quill.getSelection(true);
     self.updateActiveFormats(range);
   });

--- a/index.js
+++ b/index.js
@@ -143,3 +143,7 @@ DerbyQuill.prototype.isFocused = function() {
   var range = this.quill.getSelection();
   return !!range
 }
+
+DerbyQuill.prototype.setHTML = function(html) {
+  return this.quill.setHTML(html);
+}

--- a/index.js
+++ b/index.js
@@ -48,11 +48,11 @@ DerbyQuill.prototype.create = function() {
   this.model.on('all', 'delta.**', function(path, evtName, value, prev, passed) {
     // This change originated from this component so we
     // don't need to update ourselves
+    if (passed && passed.source == quill.id) return;
     if (typeof self._validateDelta === 'function') {
       var isValid = self._validateDelta();
       if (!isValid) return self._updateDelta();
     }
-    if (passed && passed.source == quill.id) return;
     var delta = self.delta.getDeepCopy();
     if (delta) self.quill.setContents(delta);
   });
@@ -113,13 +113,11 @@ DerbyQuill.prototype.toggleFormat = function(type) {
 };
 
 DerbyQuill.prototype.setFormat = function(type, value) {
-  console.log('Setting format', type, value);
   this.quill.focus();
   var self = this;
   window.requestAnimationFrame(function() {
     self.quill.focus();
     var range = self.quill.getSelection(true);
-    console.log('applying format', type, range, value);
     self.toolbar._applyFormat(type, range, value);
     self.activeFormats.set(type, value);
   });

--- a/index.js
+++ b/index.js
@@ -24,9 +24,9 @@ DerbyQuill.prototype.init = function() {
   this.delta = this.model.at('delta');
   this.htmlResult = this.model.at('htmlResult');
   this.plainText = this.model.at('plainText');
-  this.model.start('shouldShowPlaceholder', 'plainText', function(text) {
-    if (text === '\n') return true
-    return !text
+  this.model.start('shouldShowPlaceholder', 'htmlResult', function(html) {
+    if (html === '<div><br></div>') return true
+    return !html
   });
 };
 
@@ -133,5 +133,13 @@ DerbyQuill.prototype.focus = function() {
   var end = this.quill.getLength()
   if (end) {
     this.quill.setSelection(end, end);
+    var range = this.quill.getSelection();
+    this.updateActiveFormats(range);
   }
+}
+
+DerbyQuill.prototype.isFocused = function() {
+  if (!this.quill) return false;
+  var range = this.quill.getSelection();
+  return !!range
 }

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ var MIXED_FORMAT_VALUE = '*';
 module.exports = DerbyQuill;
 function DerbyQuill() {}
 
+DerbyQuill.Quill = Quill
 DerbyQuill.Range = Range
 
 DerbyQuill.prototype.view = __dirname;
@@ -88,6 +89,7 @@ DerbyQuill.prototype.create = function() {
     quill.setContents(delta);
   } else if (htmlValue) {
     this.setHTML(htmlValue);
+    this._updateDelta();
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ DerbyQuill.prototype.create = function() {
 
 DerbyQuill.prototype._updateDelta = function() {
   var pass = {source: this.quill.id};
-  this.delta.pass(pass).set(this.quill.editor.doc.toDelta());
+  this.delta.pass(pass).setDiffDeep(this.quill.editor.doc.toDelta());
 }
 
 DerbyQuill.prototype.clearFormatting = function() {

--- a/index.js
+++ b/index.js
@@ -2,23 +2,11 @@ var Quill = require('quill');
 var Range = Quill.require('range');
 var dom = Quill.require('dom');
 
-var LINE_FORMATS = {
-  'align': true
-};
-var BINARY_FORMATS = {
-  'bold': true
-, 'italic': true
-, 'strike': true
-, 'underline': true
-, 'link': true
-};
-var MIXED_FORMAT_VALUE = '*';
-
 module.exports = DerbyQuill;
 function DerbyQuill() {}
 
-DerbyQuill.Quill = Quill
-DerbyQuill.Range = Range
+DerbyQuill.Quill = Quill;
+DerbyQuill.Range = Range;
 
 DerbyQuill.prototype.view = __dirname;
 
@@ -30,22 +18,28 @@ DerbyQuill.prototype.init = function() {
   this.htmlResult = this.model.at('htmlResult');
   this.plainText = this.model.at('plainText');
   this.model.start('shouldShowPlaceholder', 'htmlResult', function(html) {
-    if (html === '<div><br></div>') return true
-    return !html
+    if (html === '<div><br></div>') return true;
+    return !html;
   });
 };
 
 DerbyQuill.prototype.create = function() {
   var self = this;
-  // TODO: remove this
+
   // Setup quill and initalize referneces
-  var quill = this.quill = new Quill(this.editor);
+  var quillOptions = {};
+  if (this.model.get('allowedFormats')) {
+    quillOptions.formats = this.model.get('allowedFormats');
+  }
+
+  var quill = this.quill = new Quill(this.editor, quillOptions);
   quill.addModule('toolbar', {
-    container: window.document.createElement('div')
+    container: window.document.createElement('div'),
   });
-  this.toolbar = quill.modules['toolbar']
-  this.keyboard = quill.modules['keyboard']
+  this.toolbar = quill.modules['toolbar'];
+  this.keyboard = quill.modules['keyboard'];
   if (this.model.get('focus')) this.focus();
+
   // Bind Event listners
   this.model.on('all', 'delta.**', function(path, evtName, value, prev, passed) {
     // This change originated from this component so we
@@ -54,19 +48,23 @@ DerbyQuill.prototype.create = function() {
     var delta = self.delta.getDeepCopy();
     if (delta) self.quill.setContents(delta);
   });
+
   quill.on('text-change', function(delta, source) {
     if (source === 'user') {
       self._updateDelta();
     }
+
     self.htmlResult.setDiff(quill.getHTML());
     self.plainText.setDiff(quill.getText());
     var range = quill.getSelection();
     self.updateActiveFormats(range);
   });
+
   quill.on('selection-change', function(range) {
     self.model.set('isFocused', !!range);
     self.updateActiveFormats(range);
   });
+
   // HACK: Quill should provide an event here, but we wrap the method to
   // get a hook into what's going on instead
   var prepareFormat = quill.prepareFormat;
@@ -74,6 +72,7 @@ DerbyQuill.prototype.create = function() {
     prepareFormat.call(quill, name, value);
     self.activeFormats.set(name, value);
   };
+
   // HACK: Quill added an `ignoreFocus` argument to Selection.getRange
   // that defaults to false and doesn't expose a way of setting
   // it to true from Quill.getSelection(). This will be rectified
@@ -81,7 +80,7 @@ DerbyQuill.prototype.create = function() {
   quill.getSelection = function(ignoreFocus) {
     this.editor.checkUpdate();
     return this.editor.selection.getRange(ignoreFocus);
-  }
+  };
 
   var delta = this.delta.getDeepCopy();
   var initialHtml = this.initialHtml.get();
@@ -94,16 +93,17 @@ DerbyQuill.prototype.create = function() {
 };
 
 DerbyQuill.prototype._updateDelta = function() {
-  var pass = {source: this.quill.id};
+  var pass = { source: this.quill.id };
+
   // TODO: Change to setDiffDeep once we figure out the error
   // shown here: https://lever.slack.com/files/jon/F0GH44U74/screen_shot_2015-12-13_at_3.00.37_pm.png
-  this.delta.pass(pass).set(deepyCopy(this.quill.editor.doc.toDelta()));
-}
+  this.delta.pass(pass).set(deepCopy(this.quill.editor.doc.toDelta()));
+};
 
 DerbyQuill.prototype.clearFormatting = function() {
   this.quill.focus();
   var range = this.quill.getSelection(true);
-  var formats = this.quill.editor.doc.formats
+  var formats = this.quill.editor.doc.formats;
   for (type in formats) {
     // We don't use setFormat here because we want to avoid
     // focusing the editor for each format
@@ -119,6 +119,7 @@ DerbyQuill.prototype.toggleFormat = function(type) {
 DerbyQuill.prototype.setFormat = function(type, value, isFocused) {
   if (!isFocused) this.quill.focus();
   var self = this;
+
   // HACK: Selecting an option from a dropdown
   // causes some interesting focus events which
   // require us to wait until focus has properly
@@ -127,48 +128,51 @@ DerbyQuill.prototype.setFormat = function(type, value, isFocused) {
   window.requestAnimationFrame(function() {
     if (!isFocused) self.quill.focus();
     var range;
+
     // if we are in list mode and applying a list style, then
     // we force the editor to apply that style to the entire
     // contents of the editor
     if (self.model.get('mode') === 'list' && (type === 'list' || type === 'bullet')) {
       var end = self.quill.getLength() || 0;
       range = new Range(0, end);
-      value = true
+      value = true;
     } else {
       range = self.quill.getSelection(true);
     }
+
     self.toolbar._applyFormat(type, range, value);
     self.activeFormats.set(type, value);
   });
 };
 
 DerbyQuill.prototype.updateActiveFormats = function(range) {
-  var activeFormats = {}
+  var activeFormats = {};
   if (range) {
     activeFormats = this.getActiveFormats(range);
   }
+
   this.activeFormats.set(activeFormats);
 };
 
 // Formats that span the entire range
 DerbyQuill.prototype.getActiveFormats = function(range) {
-  return this.toolbar._getActive(range)
+  return this.toolbar._getActive(range);
 };
 
 DerbyQuill.prototype.focus = function() {
-  var end = this.quill.getLength()
+  var end = this.quill.getLength();
   if (end) {
     this.quill.setSelection(end, end);
     var range = this.quill.getSelection();
     this.updateActiveFormats(range);
     this.model.set('isFocused', true);
   }
-}
+};
 
 DerbyQuill.prototype.setHTML = function(html) {
   return this.quill.setHTML(html);
-}
+};
 
-deepyCopy = function(obj) {
+deepCopy = function(obj) {
   return JSON.parse(JSON.stringify(obj));
-}
+};

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ DerbyQuill.prototype.init = function() {
   this.quill = null;
   this.activeFormats = this.model.at('activeFormats');
   this.delta = this.model.at('delta');
-  this.markup = this.model.at('markup');
+  this.htmlResult = this.model.at('htmlResult');
   this.plainText = this.model.at('plainText');
 };
 
@@ -37,7 +37,7 @@ DerbyQuill.prototype.create = function() {
 
   quill.on('text-change', function() {
     self.delta.pass({source: quill}).setDiffDeep(quill.editor.doc.toDelta())
-    self.markup.set(quill.getHTML());
+    self.htmlResult.set(quill.getHTML());
     self.plainText.set(quill.getText());
     var range = quill.getSelection(true);
     self.updateActiveFormats(range);

--- a/index.js
+++ b/index.js
@@ -42,9 +42,13 @@ DerbyQuill.prototype.create = function() {
 
   // Fix how keyboard hotkeys affect toolbar buttons
   var hotkeyToggleFormat = function(format) {
-    return function() {
+    return function(range) {
       var newValue = !self.activeFormats.get(format);
-      quill.prepareFormat(format, newValue);
+      if (range.isCollapsed()) {
+        quill.prepareFormat(format, newValue);
+      } else {
+        self.toolbar._applyFormat(format, range, newValue);
+      }
       return false;
     };
   };

--- a/index.js
+++ b/index.js
@@ -36,15 +36,11 @@ DerbyQuill.prototype.init = function() {
 DerbyQuill.prototype.create = function() {
   var self = this;
   // TODO: remove this
-  window.Quill = Quill;
-  window.dom = dom;
   // Setup quill and initalize referneces
   var quill = this.quill = new Quill(this.editor);
   quill.addModule('toolbar', {
     container: window.document.createElement('div')
   });
-  window.toolbar = this.toolbar = quill.modules['toolbar']
-  window.keyboard = this.keyboard = quill.modules['keyboard']
   if (this.model.get('focus')) this.focus();
 
   // Bind Event listners

--- a/index.js
+++ b/index.js
@@ -40,6 +40,23 @@ DerbyQuill.prototype.create = function() {
   this.keyboard = quill.modules['keyboard'];
   if (this.model.get('focus')) this.focus();
 
+  // Fix how keyboard hotkeys affect toolbar buttons
+  var hotkeyToggleFormat = function(format) {
+    return function() {
+      var newValue = !self.activeFormats.get(format);
+      quill.prepareFormat(format, newValue);
+      return false;
+    };
+  };
+  var fixHotkey = function(key, format) {
+    var keyCode = key.toUpperCase().charCodeAt(0);
+    self.keyboard.hotkeys[keyCode] = [];
+    self.keyboard.addHotkey({key: keyCode, metaKey: true}, hotkeyToggleFormat(format));
+  };
+  fixHotkey('B', 'bold');
+  fixHotkey('I', 'italic');
+  fixHotkey('U', 'underline');
+
   // Bind Event listners
   this.model.on('all', 'delta.**', function(path, evtName, value, prev, passed) {
     // This change originated from this component so we

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ DerbyQuill.prototype.init = function() {
   this.quill = null;
   this.activeFormats = this.model.at('activeFormats');
   this.delta = this.model.at('delta');
-  this.htmlValue = this.model.at('htmlValue');
+  this.initialHtml = this.model.at('initialHtml');
   this.htmlResult = this.model.at('htmlResult');
   this.plainText = this.model.at('plainText');
   this.model.start('shouldShowPlaceholder', 'htmlResult', function(html) {
@@ -84,11 +84,11 @@ DerbyQuill.prototype.create = function() {
   }
 
   var delta = this.delta.getDeepCopy();
-  var htmlValue = this.htmlValue.get();
+  var initialHtml = this.initialHtml.get();
   if (delta) {
     quill.setContents(delta);
-  } else if (htmlValue) {
-    this.setHTML(htmlValue);
+  } else if (initialHtml) {
+    this.setHTML(initialHtml);
     this._updateDelta();
   }
 };

--- a/index.js
+++ b/index.js
@@ -45,13 +45,6 @@ DerbyQuill.prototype.create = function() {
 
   // Bind Event listners
   this.model.on('all', 'delta.**', function(path, evtName, value, prev, passed) {
-    // if a validate function has been provided, then
-    // we run it to ensure the contents of the editor
-    // meets the defined restrictions
-    if (typeof self._validateDelta === 'function') {
-      var isValid = self._validateDelta();
-      if (!isValid) return self._updateDelta();
-    }
     // This change originated from this component so we
     // don't need to update ourselves
     if (passed && passed.source == quill.id) return;

--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ DerbyQuill.prototype.create = function() {
     self.updateActiveFormats(range);
   });
   quill.on('selection-change', function(range) {
+    self.model.set('isFocused', !!range);
     self.updateActiveFormats(range);
   });
   // HACK: Quill should provide an event here, but we wrap the method to

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Nate Smith",
   "license": "MIT",
   "dependencies": {
-    "lever-quill": "^1.0.0"
+    "lever-quill": "^1.1.0"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Nate Smith",
   "license": "MIT",
   "dependencies": {
-    "quill": "^0.20.1"
+    "lever-quill": "^1.0.0"
   },
   "devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Nate Smith",
   "license": "MIT",
   "dependencies": {
-    "quilljs": "^0.13.4"
+    "quill": "^0.20.1"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
- Updates formatting and selection logic to use new internal Quill functions
- Removes some old workarounds that are not needed anymore
- Introduces new workarounds that are now needed
  - `getSelection` shim
  -  `requestAnimationFrame` when applying toolbar styes to work around issue with using dropdowns within the toolbar
- maintains and exposes the internal html and text representations of the editor via `this.model.plainText` and `this.model.htmlResult`
- Changes the name of the input attribute from `input` to `delta` to represent the fact the component expects a `Quill.Delta` object as its input.
- Adds `placeholder` and `focus` support
- fixes `clearFormatting` for every cursor/selection case
- toggles toolbar buttons correctly when using keyboard hotkeys
